### PR TITLE
Add repository link to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Hunter Schafer <hschafer@uw.edu>"]
 license = "MIT"
 readme = "README.md"
 packages = [{include = "teachingtoolshed"}]
+repository = "https://github.com/hschafer/teaching-toolshed"
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
This helps people find the github repo from PyPI.